### PR TITLE
Allow specifying a token handler

### DIFF
--- a/packages.lisp
+++ b/packages.lisp
@@ -61,6 +61,7 @@
    #:parse-html5
    #:parse-html5-fragment
    #:transform-html5-dom
+   #:process-token
 
    ;; A simple DOM
    #:make-document


### PR DESCRIPTION
This adds support for a useful idea from libhubbub: SAX-style parsing. The actual changes required are very simple: adding a `token-handler` argument to the parsing functions. If provided, the user's token handler is called for each token instead of `process-token`, and no DOM is built.

Obviously HTML is not XML, and SAX-style parsing is not nearly as useful, but it still makes a big difference in cases where we're only interested in the tokenization phase, like stripping markup or extracting links.