### PR TITLE
Fix MAKE-GROWABLE-STRING

### DIFF
--- a/tokenizer.lisp
+++ b/tokenizer.lisp
@@ -73,10 +73,9 @@ pointer at the end."
           (make-array (max 5 (length init))
                       :element-type 'character
                       :adjustable t
-                      :fill-pointer 0)))
+                      :fill-pointer (length init))))
     (when init
-      (loop for c across init
-            do (vector-push-extend c string (length string))))
+      (replace string init))
     string))
 
 (defun nconcat (string &rest data)


### PR DESCRIPTION
MAKE-GROWABLE-STRING sets the growable string's initial contents by
pushing characters from INIT, one by one.  It supplied
VECTOR-PUSH-EXTEND with an extension argument that is the growable's
string length.  This may have been done in order to effectively double
the string's capacity, but initially the extension argument is zero,
which violates the HyperSpec's requirement of it being positive.

Instead of pushing characters one by one, use REPLACE.