### PR TITLE
Fix UTF-8 BOM detection.

### DIFF
--- a/inputstream.lisp
+++ b/inputstream.lisp
@@ -153,7 +153,7 @@
              :utf-16le)
             ((and (eql byte-0 #xef)
                   (eql byte-1 #xbb)
-                  (eql byte-1 #xbf))
+                  (eql byte-2 #xbf))
              :utf-8)))))
 
 ;; 12.2.2.3 Changing the encoding while parsing


### PR DESCRIPTION
The detection of UTF-8 BOM was broken. Instead of checking the third byte, it checked the second byte twice.